### PR TITLE
all: upgrade to Jedis 3.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: "net.ltgt.errorprone"
 apply plugin: "signing"
 
 group = "io.orijtech.integrations"
-version = "0.0.2" // CURRENT_OCJEDIS_VERSION
+version = "0.0.3" // CURRENT_OCJEDIS_VERSION
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -47,7 +47,7 @@ dependencies {
     runtime "io.opencensus:opencensus-impl:${opencensusVersion}"
 
     // https://mvnrepository.com/artifact/redis.clients/jedis
-    compile group: 'redis.clients', name: 'jedis', version: '2.9.0'
+    compile group: 'redis.clients', name: 'jedis', version: '3.0.1'
 
     compileOnly "com.google.code.findbugs:jsr305:${findBugsJsr305Version}"
     compileOnly "com.google.errorprone:error_prone_annotations:${errorProneVersion}"

--- a/src/main/java/io/orijtech/integrations/ocjedis/OcWrapJedis.java
+++ b/src/main/java/io/orijtech/integrations/ocjedis/OcWrapJedis.java
@@ -23,26 +23,27 @@ import java.util.Set;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
-import redis.clients.jedis.BinaryClient;
 import redis.clients.jedis.BitOP;
 import redis.clients.jedis.BitPosParams;
+import redis.clients.jedis.ClusterReset;
 import redis.clients.jedis.GeoCoordinate;
 import redis.clients.jedis.GeoRadiusResponse;
 import redis.clients.jedis.GeoUnit;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.JedisPoolAbstract;
 import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.JedisShardInfo;
+import redis.clients.jedis.ListPosition;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.SortingParams;
 import redis.clients.jedis.Tuple;
 import redis.clients.jedis.ZParams;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
-import redis.clients.util.Pool;
-import redis.clients.util.Slowlog;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
+import redis.clients.jedis.util.Slowlog;
 
 public class OcWrapJedis extends Jedis {
 
@@ -165,7 +166,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long append(String key, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#append-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#append-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.append", key);
 
@@ -182,7 +183,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long bitcount(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#bitcount-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#bitcount-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.bitcount", key);
 
@@ -199,7 +200,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long bitcount(String key, long start, long end) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#bitcount-java.lang.String-long-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#bitcount-java.lang.String-long-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.bitcount", key);
 
@@ -216,7 +217,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<Long> bitfield(String key, String... arguments) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#bitfield-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#bitfield-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.bitfield", key);
 
@@ -233,7 +234,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long bitop(BitOP op, String destKey, String... srcKeys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#bitop-redis.clients.jedis.BitOP-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#bitop-redis.clients.jedis.BitOP-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.bitop", srcKeys);
 
@@ -250,7 +251,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long bitpos(String key, boolean value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#bitpos-java.lang.String-boolean-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#bitpos-java.lang.String-boolean-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.bitpos", key);
 
@@ -267,7 +268,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long bitpos(String key, boolean value, BitPosParams params) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#bitpos-java.lang.String-boolean-redis.clients.jedis.BitPosParams-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#bitpos-java.lang.String-boolean-redis.clients.jedis.BitPosParams-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.bitpos", key);
 
@@ -284,7 +285,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> blpop(int timeout, String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#blpop-int-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#blpop-int-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.blpop", keys);
 
@@ -301,7 +302,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> blpop(int timeout, String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#blpop-int-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#blpop-int-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.blpop", key);
 
@@ -318,7 +319,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> blpop(String... args) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#blpop-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#blpop-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.blpop");
 
@@ -335,7 +336,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> brpop(int timeout, String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#brpop-int-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#brpop-int-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.brpop", keys);
 
@@ -352,7 +353,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> brpop(int timeout, String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#brpop-int-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#brpop-int-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.brpop", key);
 
@@ -369,7 +370,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> brpop(String... args) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#brpop-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#brpop-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.brpop");
 
@@ -386,7 +387,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String brpoplpush(String source, String destination, int timeout) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#brpoplpush-java.lang.String-java.lang.String-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#brpoplpush-java.lang.String-java.lang.String-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.brpoplpush");
 
@@ -403,7 +404,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clientKill(String client) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clientKill-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clientKill-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clientKill");
 
@@ -420,7 +421,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clientSetname(String name) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clientSetname-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clientSetname-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clientSetname");
 
@@ -437,7 +438,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public void close() {
     // This method makes a call over the network or at least we need to track closes.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#close--
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#close--
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.close");
 
@@ -454,7 +455,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterAddSlots(int... slots) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterAddSlots-int...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterAddSlots-int...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterAddSlots");
 
@@ -471,7 +472,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long clusterCountKeysInSlot(int slot) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterCountKeysInSlot-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterCountKeysInSlot-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.clusterCountKeysInSlot");
@@ -489,7 +490,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterDelSlots(int... slots) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterDelSlots-int...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterDelSlots-int...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterDelSlots");
 
@@ -506,7 +507,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterFailover() {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterFailover--
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterFailover--
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterFailover");
 
@@ -523,7 +524,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterFlushSlots() {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterFlushSlots--
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterFlushSlots--
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterFlushSlots");
 
@@ -540,7 +541,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterForget(String nodeId) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterForget-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterForget-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterForget");
 
@@ -557,7 +558,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> clusterGetKeysInSlot(int slot, int count) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterGetKeysInSlot-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterGetKeysInSlot-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterGetKeysInSlot");
 
@@ -574,7 +575,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterInfo() {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterInfo--
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterInfo--
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterInfo");
 
@@ -591,7 +592,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long clusterKeySlot(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterKeySlot-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterKeySlot-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterKeySlot", key);
 
@@ -608,7 +609,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterMeet(String ip, int port) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterMeet-java.lang.String-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterMeet-java.lang.String-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterMeet");
 
@@ -625,7 +626,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterNodes() {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterNodes--
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterNodes--
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterNodes");
 
@@ -642,7 +643,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterReplicate(String nodeId) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterReplicate-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterReplicate-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterReplicate");
 
@@ -657,9 +658,9 @@ public class OcWrapJedis extends Jedis {
   }
 
   @Override
-  public String clusterReset(JedisCluster.Reset resetType) {
+  public String clusterReset(ClusterReset resetType) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterReset-redis.clients.jedis.JedisCluster.Reset-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterReset-redis.clients.jedis.ClusterReset-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterReset");
 
@@ -676,7 +677,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterSaveConfig() {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterSaveConfig--
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterSaveConfig--
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterSaveConfig");
 
@@ -693,7 +694,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterSetSlotImporting(int slot, String nodeId) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterSetSlotImporting-int-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterSetSlotImporting-int-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.clusterSetSlotImporting");
@@ -711,7 +712,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterSetSlotMigrating(int slot, String nodeId) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterSetSlotMigrating-int-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterSetSlotMigrating-int-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.clusterSetSlotMigrating");
@@ -729,7 +730,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterSetSlotNode(int slot, String nodeId) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterSetSlotNode-int-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterSetSlotNode-int-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterSetSlotNode");
 
@@ -746,7 +747,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String clusterSetSlotStable(int slot) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterSetSlotStable-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterSetSlotStable-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterSetSlotStable");
 
@@ -763,7 +764,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> clusterSlaves(String nodeId) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterSlaves-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterSlaves-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterSlaves");
 
@@ -780,7 +781,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<Object> clusterSlots() {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#clusterSlots--
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#clusterSlots--
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.clusterSlots");
 
@@ -797,7 +798,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> configGet(String pattern) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#configGet-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#configGet-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.configGet");
 
@@ -814,7 +815,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String configSet(String parameter, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#configSet-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#configSet-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.configSet");
 
@@ -831,7 +832,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long decr(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#decr-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#decr-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.decr");
 
@@ -848,7 +849,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long decrBy(String key, long integer) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#decrBy-java.lang.String-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#decrBy-java.lang.String-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.decrBy");
 
@@ -865,7 +866,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long del(String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#decrBy-java.lang.String-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#decrBy-java.lang.String-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.del", keys);
 
@@ -882,7 +883,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long del(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#del-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#del-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.del");
 
@@ -899,7 +900,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public byte[] dump(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#dump-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#dump-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.dump", key);
 
@@ -916,7 +917,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String echo(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#echo-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#echo-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.echo", key);
 
@@ -933,7 +934,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Object eval(String script) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#eval-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#eval-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.eval", script);
 
@@ -950,7 +951,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Object eval(String script, int keyCount, String... params) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#eval-java.lang.String-int-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#eval-java.lang.String-int-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.eval", script);
 
@@ -967,7 +968,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Object eval(String script, List<String> keys, List<String> args) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#eval-java.lang.String-java.util.List-java.util.List-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#eval-java.lang.String-java.util.List-java.util.List-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.eval", script);
 
@@ -984,7 +985,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Object evalsha(String sha1) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#evalsha-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#evalsha-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.evalsha", sha1);
 
@@ -1001,7 +1002,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Object evalsha(String sha1, int keyCount, String... params) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#evalsha-java.lang.String-int-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#evalsha-java.lang.String-int-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.evalsha", sha1);
 
@@ -1018,7 +1019,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Object evalsha(String sha1, List<String> keys, List<String> args) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#evalsha-java.lang.String-java.util.List-java.util.List-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#evalsha-java.lang.String-java.util.List-java.util.List-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.evalsha", sha1);
 
@@ -1035,7 +1036,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long exists(String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#exists-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#exists-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.exists", keys);
 
@@ -1052,7 +1053,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Boolean exists(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#exists-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#exists-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.exists", key);
 
@@ -1069,7 +1070,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long expire(String key, int seconds) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#expire-java.lang.String-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#expire-java.lang.String-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.expire", key);
 
@@ -1086,7 +1087,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long expireAt(String key, long unixTime) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#expireAt-java.lang.String-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#expireAt-java.lang.String-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.expireAt", key);
 
@@ -1103,7 +1104,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long geoadd(String key, double longitude, double latitude, String member) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#geoadd-java.lang.String-double-double-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#geoadd-java.lang.String-double-double-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.geoadd", key);
 
@@ -1120,7 +1121,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long geoadd(String key, Map<String, GeoCoordinate> memberCoordinateMap) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#geoadd-java.lang.String-double-double-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#geoadd-java.lang.String-double-double-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.geoadd", key);
 
@@ -1137,7 +1138,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Double geodist(String key, String member1, String member2) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#geodist-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#geodist-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.geodist", key);
 
@@ -1154,7 +1155,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Double geodist(String key, String member1, String member2, GeoUnit unit) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#geodist-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#geodist-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.geodist", key);
 
@@ -1171,7 +1172,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> geohash(String key, String... members) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#geohash-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#geohash-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.geohash", key);
 
@@ -1188,7 +1189,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<GeoCoordinate> geopos(String key, String... members) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#geopos-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#geopos-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.geopos", key);
 
@@ -1206,7 +1207,7 @@ public class OcWrapJedis extends Jedis {
   public List<GeoRadiusResponse> georadius(
       String key, double longitude, double latitude, double radius, GeoUnit unit) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#georadius-java.lang.String-double-double-double-redis.clients.jedis.GeoUnit-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#georadius-java.lang.String-double-double-double-redis.clients.jedis.GeoUnit-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.georadius", key);
 
@@ -1229,7 +1230,7 @@ public class OcWrapJedis extends Jedis {
       GeoUnit unit,
       GeoRadiusParam param) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#georadius-java.lang.String-double-double-double-redis.clients.jedis.GeoUnit-redis.clients.jedis.params.geo.GeoRadiusParam-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#georadius-java.lang.String-double-double-double-redis.clients.jedis.GeoUnit-redis.clients.jedis.params.geo.GeoRadiusParam-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.georadius", key);
 
@@ -1247,7 +1248,7 @@ public class OcWrapJedis extends Jedis {
   public List<GeoRadiusResponse> georadiusByMember(
       String key, String member, double radius, GeoUnit unit) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#georadiusByMember-java.lang.String-java.lang.String-double-redis.clients.jedis.GeoUnit-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#georadiusByMember-java.lang.String-java.lang.String-double-redis.clients.jedis.GeoUnit-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.georadiusByMember", key);
@@ -1266,7 +1267,7 @@ public class OcWrapJedis extends Jedis {
   public List<GeoRadiusResponse> georadiusByMember(
       String key, String member, double radius, GeoUnit unit, GeoRadiusParam param) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#georadiusByMember-java.lang.String-java.lang.String-double-redis.clients.jedis.GeoUnit-redis.clients.jedis.params.geo.GeoRadiusParam-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#georadiusByMember-java.lang.String-java.lang.String-double-redis.clients.jedis.GeoUnit-redis.clients.jedis.params.geo.GeoRadiusParam-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.georadiusByMember", key);
@@ -1284,7 +1285,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String get(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#get-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#get-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.get", key);
 
@@ -1301,7 +1302,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Boolean getbit(String key, long offset) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#getbit-java.lang.String-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#getbit-java.lang.String-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.getbit", key);
 
@@ -1318,7 +1319,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String getrange(String key, long startOffset, long endOffset) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#getrange-java.lang.String-long-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#getrange-java.lang.String-long-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.getrange", key);
 
@@ -1335,7 +1336,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String getSet(String key, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#getSet-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#getSet-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.getSet", key);
 
@@ -1352,7 +1353,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long hdel(String key, String... fields) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hdel-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hdel-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hdel", key);
 
@@ -1369,7 +1370,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Boolean hexists(String key, String field) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hexists-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hexists-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hexists", key);
 
@@ -1386,7 +1387,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String hget(String key, String field) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hget-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hget-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hget", key);
 
@@ -1403,7 +1404,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Map<String, String> hgetAll(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hgetAll-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hgetAll-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hgetAll", key);
 
@@ -1420,7 +1421,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long hincrBy(String key, String field, long value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hincrBy-java.lang.String-java.lang.String-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hincrBy-java.lang.String-java.lang.String-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hincrBy", key);
 
@@ -1437,7 +1438,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Double hincrByFloat(String key, String field, double value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hincrByFloat-java.lang.String-java.lang.String-double-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hincrByFloat-java.lang.String-java.lang.String-double-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hincrByFloat", key);
 
@@ -1454,7 +1455,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> hkeys(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hkeys-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hkeys-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hkeys", key);
 
@@ -1471,7 +1472,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long hlen(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hlen-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hlen-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hlen", key);
 
@@ -1488,7 +1489,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> hmget(String key, String... fields) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hmget-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hmget-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hmget", key);
 
@@ -1505,7 +1506,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public ScanResult<Map.Entry<String, String>> hscan(String key, String cursor) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hscan-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hscan-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hscan", key);
 
@@ -1522,7 +1523,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public ScanResult<Map.Entry<String, String>> hscan(String key, String cursor, ScanParams params) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hscan-java.lang.String-java.lang.String-redis.clients.jedis.ScanParams-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hscan-java.lang.String-java.lang.String-redis.clients.jedis.ScanParams-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hscan", key);
 
@@ -1539,7 +1540,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long hset(String key, String field, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hset-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hset-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hset", key);
 
@@ -1556,7 +1557,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long hsetnx(String key, String field, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hsetnx-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hsetnx-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hsetnx", key);
 
@@ -1573,7 +1574,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> hvals(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#hvals-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#hvals-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.hvals", key);
 
@@ -1590,7 +1591,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long incr(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#incr-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#incr-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.incr", key);
 
@@ -1607,7 +1608,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long incrBy(String key, long integer) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#incrBy-java.lang.String-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#incrBy-java.lang.String-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.incrBy", key);
 
@@ -1624,7 +1625,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Double incrByFloat(String key, double value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#incrByFloat-java.lang.String-double-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#incrByFloat-java.lang.String-double-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.incrByFloat", key);
 
@@ -1641,7 +1642,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> keys(String pattern) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#keys-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#keys-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.keys", pattern);
 
@@ -1658,7 +1659,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String lindex(String key, long index) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#lindex-java.lang.String-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#lindex-java.lang.String-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.lindex", key);
 
@@ -1673,9 +1674,9 @@ public class OcWrapJedis extends Jedis {
   }
 
   @Override
-  public Long linsert(String key, BinaryClient.LIST_POSITION where, String pivot, String value) {
+  public Long linsert(String key, ListPosition where, String pivot, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#linsert-java.lang.String-redis.clients.jedis.BinaryClient.LIST_POSITION-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#linsert-java.lang.String-redis.clients.jedis.ListPosition-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.linsert", key);
 
@@ -1692,7 +1693,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long llen(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#llen-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#llen-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.llen", key);
 
@@ -1709,7 +1710,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String lpop(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#lpop-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#lpop-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.lpop", key);
 
@@ -1726,7 +1727,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long lpush(String key, String... strings) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#lpush-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#lpush-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.lpush", key);
 
@@ -1743,7 +1744,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long lpushx(String key, String... strings) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#lpushx-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#lpushx-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.lpushx", key);
 
@@ -1760,7 +1761,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> lrange(String key, long start, long end) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#lrange-java.lang.String-long-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#lrange-java.lang.String-long-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.lrange", key);
 
@@ -1777,7 +1778,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long lrem(String key, long count, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#lrem-java.lang.String-long-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#lrem-java.lang.String-long-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.lrem", key);
 
@@ -1794,7 +1795,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String lset(String key, long index, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#lset-java.lang.String-long-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#lset-java.lang.String-long-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.lset", key);
 
@@ -1811,7 +1812,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String ltrim(String key, long start, long end) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#ltrim-java.lang.String-long-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#ltrim-java.lang.String-long-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.ltrim", key);
 
@@ -1828,7 +1829,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> mget(String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#mget-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#mget-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.mget", keys);
 
@@ -1845,7 +1846,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String migrate(String host, int port, String key, int destinationDb, int timeout) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#migrate-java.lang.String-int-java.lang.String-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#migrate-java.lang.String-int-java.lang.String-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.migrate", key);
 
@@ -1862,7 +1863,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long move(String key, int dbIndex) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#move-java.lang.String-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#move-java.lang.String-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.move", key);
 
@@ -1879,7 +1880,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String mset(String... keysvalues) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#mset-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#mset-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.mset", keysvalues);
 
@@ -1896,7 +1897,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long msetnx(String... keysvalues) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#msetnx-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#msetnx-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.msetnx", keysvalues);
 
@@ -1913,7 +1914,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String objectEncoding(String string) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#objectEncoding-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#objectEncoding-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.objectEncoding", string);
@@ -1931,7 +1932,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long objectIdletime(String string) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#objectIdletime-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#objectIdletime-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.objectIdletime", string);
@@ -1949,7 +1950,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long objectRefcount(String string) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#objectRefcount-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#objectRefcount-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.objectRefcount", string);
@@ -1967,7 +1968,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long persist(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#persist-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#persist-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.persist", key);
 
@@ -1984,7 +1985,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long pexpire(String key, long milliseconds) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#pexpire-java.lang.String-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#pexpire-java.lang.String-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.pexpire", key);
 
@@ -2001,7 +2002,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long pexpireAt(String key, long millisecondsTimestamp) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#pexpireAt-java.lang.String-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#pexpireAt-java.lang.String-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.pexpireAt", key);
 
@@ -2018,7 +2019,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long pfadd(String key, String... elements) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#pfadd-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#pfadd-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.pfadd", key);
 
@@ -2035,7 +2036,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public long pfcount(String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#pfcount-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#pfcount-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.pfcount", keys);
 
@@ -2052,7 +2053,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public long pfcount(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#pfcount-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#pfcount-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.pfcount", key);
 
@@ -2069,7 +2070,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String pfmerge(String destkey, String... sourcekeys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#pfmerge-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#pfmerge-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.pfmerge", destkey);
 
@@ -2086,7 +2087,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String psetex(String key, long milliseconds, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#psetex-java.lang.String-long-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#psetex-java.lang.String-long-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.psetex", key);
 
@@ -2103,7 +2104,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public void psubscribe(JedisPubSub jedisPubSub, String... patterns) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#psubscribe-redis.clients.jedis.JedisPubSub-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#psubscribe-redis.clients.jedis.JedisPubSub-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.psubscribe", patterns);
 
@@ -2120,7 +2121,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long pttl(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#pttl-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#pttl-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.pttl", key);
 
@@ -2137,7 +2138,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long publish(String channel, String message) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#publish-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#publish-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.publish", channel, message);
@@ -2155,7 +2156,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> pubsubChannels(String pattern) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#pubsubChannels-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#pubsubChannels-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.pubsubChannels", pattern);
@@ -2173,7 +2174,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long pubsubNumPat() {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#pubsubNumPat--
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#pubsubNumPat--
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.pubsubNumPat");
 
@@ -2190,7 +2191,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Map<String, String> pubsubNumSub(String... channels) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#pubsubNumSub-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#pubsubNumSub-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.pubsubNumSub", channels);
@@ -2208,7 +2209,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String randomKey() {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#randomKey--
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#randomKey--
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.randomKey");
 
@@ -2225,7 +2226,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String readonly() {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#readonly--
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#readonly--
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.readonly");
 
@@ -2242,7 +2243,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String rename(String oldkey, String newkey) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#rename-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#rename-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.rename", oldkey, newkey);
@@ -2260,7 +2261,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long renamenx(String oldkey, String newkey) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#renamenx-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#renamenx-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.renamenx", oldkey, newkey);
@@ -2278,7 +2279,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String restore(String key, int ttl, byte[] serializedValue) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#restore-java.lang.String-int-byte:A-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#restore-java.lang.String-int-byte:A-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.restore", key);
 
@@ -2295,7 +2296,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String rpoplpush(String srckey, String dstkey) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#rpoplpush-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#rpoplpush-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.rpoplpush", srckey, dstkey);
@@ -2313,7 +2314,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long rpush(String key, String... strings) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#rpush-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#rpush-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.rpush", key);
 
@@ -2330,7 +2331,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long rpushx(String key, String... strings) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#rpushx-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#rpushx-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.rpushx", key);
 
@@ -2347,7 +2348,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long sadd(String key, String... members) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sadd-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sadd-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sadd", key);
 
@@ -2364,7 +2365,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public ScanResult<String> scan(String cursor) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#scan-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#scan-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.scan", cursor);
 
@@ -2381,7 +2382,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public ScanResult<String> scan(String cursor, ScanParams params) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#scan-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#scan-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.scan", cursor);
 
@@ -2398,7 +2399,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long scard(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#scard-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#scard-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.scard", key);
 
@@ -2415,7 +2416,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<Boolean> scriptExists(String... sha1s) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#scriptExists-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#scriptExists-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.scriptExists", sha1s);
 
@@ -2432,7 +2433,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Boolean scriptExists(String sha1) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#scriptExists-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#scriptExists-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.scriptExists", sha1);
 
@@ -2449,7 +2450,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String scriptLoad(String script) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#scriptLoad-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#scriptLoad-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.scriptLoad", script);
 
@@ -2466,7 +2467,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> sdiff(String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sdiff-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sdiff-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sdiff", keys);
 
@@ -2483,7 +2484,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long sdiffstore(String dstkey, String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sdiffstore-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sdiffstore-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sdiffstore", dstkey);
 
@@ -2500,7 +2501,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String sentinelFailover(String masterName) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sentinelFailover-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sentinelFailover-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.sentinelFailover", masterName);
@@ -2518,7 +2519,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> sentinelGetMasterAddrByName(String masterName) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sentinelGetMasterAddrByName-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sentinelGetMasterAddrByName-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.sentinelGetMasterAddrByName", masterName);
@@ -2536,7 +2537,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<Map<String, String>> sentinelMasters() {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sentinelMasters--
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sentinelMasters--
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sentinelMasters");
 
@@ -2553,7 +2554,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String sentinelMonitor(String masterName, String ip, int port, int quorum) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sentinelMonitor-java.lang.String-java.lang.String-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sentinelMonitor-java.lang.String-java.lang.String-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.sentinelMonitor", masterName);
@@ -2571,7 +2572,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String sentinelRemove(String masterName) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sentinelRemove-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sentinelRemove-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.sentinelRemove", masterName);
@@ -2589,7 +2590,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long sentinelReset(String pattern) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sentinelReset-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sentinelReset-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.sentinelReset", pattern);
@@ -2607,7 +2608,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String sentinelSet(String masterName, Map<String, String> parameterMap) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sentinelSet-java.lang.String-java.util.Map-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sentinelSet-java.lang.String-java.util.Map-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.sentinelSet", masterName);
@@ -2625,7 +2626,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<Map<String, String>> sentinelSlaves(String masterName) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sentinelSlaves-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sentinelSlaves-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.sentinelSlaves", masterName);
@@ -2643,7 +2644,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String set(String key, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#set-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#set-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.set", key);
 
@@ -2658,48 +2659,14 @@ public class OcWrapJedis extends Jedis {
   }
 
   @Override
-  public String set(String key, String value, String nxxx) {
+  public String set(String key, String value, SetParams params) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#set-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#set-java.lang.String-java.lang.String-redis.clients.jedis.params.SetParams-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.set", key);
 
     try (Scope ws = trackingOperation.withSpan()) {
-      return super.set(key, value, nxxx);
-    } catch (Exception e) {
-      trackingOperation.recordException(e);
-      throw e;
-    } finally {
-      trackingOperation.end();
-    }
-  }
-
-  @Override
-  public String set(String key, String value, String nxxx, String expx, int time) {
-    // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#set-java.lang.String-java.lang.String-java.lang.String-java.lang.String-int-
-    TrackingOperation trackingOperation =
-        Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.set", key);
-
-    try (Scope ws = trackingOperation.withSpan()) {
-      return super.set(key, value, nxxx, expx, time);
-    } catch (Exception e) {
-      trackingOperation.recordException(e);
-      throw e;
-    } finally {
-      trackingOperation.end();
-    }
-  }
-
-  @Override
-  public String set(String key, String value, String nxxx, String expx, long time) {
-    // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#set-java.lang.String-java.lang.String-java.lang.String-java.lang.String-long-
-    TrackingOperation trackingOperation =
-        Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.set", key);
-
-    try (Scope ws = trackingOperation.withSpan()) {
-      return super.set(key, value, nxxx, expx, time);
+      return super.set(key, value, params);
     } catch (Exception e) {
       trackingOperation.recordException(e);
       throw e;
@@ -2711,7 +2678,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Boolean setbit(String key, long offset, boolean value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#setbit-java.lang.String-long-boolean-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#setbit-java.lang.String-long-boolean-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.setbit", key);
 
@@ -2728,7 +2695,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Boolean setbit(String key, long offset, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#setbit-java.lang.String-long-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#setbit-java.lang.String-long-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.setbit", key);
 
@@ -2743,9 +2710,9 @@ public class OcWrapJedis extends Jedis {
   }
 
   @Override
-  public void setDataSource(Pool<Jedis> jedisPool) {
+  public void setDataSource(JedisPoolAbstract jedisPool) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#setDataSource-redis.clients.util.Pool-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#setDataSource-redis.clients.jedis.JedisPoolAbstract-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.setDataSource");
 
@@ -2762,7 +2729,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String setex(String key, int seconds, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#setex-java.lang.String-int-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#setex-java.lang.String-int-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.setex");
 
@@ -2779,7 +2746,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long setnx(String key, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#setnx-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#setnx-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.setnx");
 
@@ -2796,7 +2763,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long setrange(String key, long offset, String value) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#setrange-java.lang.String-long-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#setrange-java.lang.String-long-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.setrange", key);
 
@@ -2813,7 +2780,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> sinter(String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sinter-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sinter-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sinter", keys);
 
@@ -2830,7 +2797,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long sinterstore(String dstkey, String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sinterstore-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sinterstore-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sinterstore", dstkey);
 
@@ -2847,7 +2814,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Boolean sismember(String key, String member) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sismember-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sismember-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sismember", key);
 
@@ -2864,7 +2831,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<Slowlog> slowlogGet() {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#slowlogGet--
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#slowlogGet--
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.slowlogGet");
 
@@ -2881,7 +2848,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<Slowlog> slowlogGet(long entries) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#slowlogGet-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#slowlogGet-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.slowlogGet");
 
@@ -2898,7 +2865,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> smembers(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#smembers-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#smembers-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.smembers", key);
 
@@ -2915,7 +2882,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long smove(String srckey, String dstkey, String member) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#smove-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#smove-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.smove", srckey, dstkey);
@@ -2933,7 +2900,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> sort(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sort-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sort-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sort", key);
 
@@ -2950,7 +2917,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> sort(String key, SortingParams sortingParameters) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sort-java.lang.String-redis.clients.jedis.SortingParams-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sort-java.lang.String-redis.clients.jedis.SortingParams-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sort", key);
 
@@ -2967,7 +2934,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long sort(String key, SortingParams sortingParameters, String dstkey) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sort-java.lang.String-redis.clients.jedis.SortingParams-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sort-java.lang.String-redis.clients.jedis.SortingParams-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sort", key, dstkey);
 
@@ -2984,7 +2951,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long sort(String key, String dstkey) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sort-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sort-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sort", key, dstkey);
 
@@ -3001,7 +2968,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String spop(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#spop-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#spop-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.spop", key);
 
@@ -3018,7 +2985,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> spop(String key, long count) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#spop-java.lang.String-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#spop-java.lang.String-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.spop", key);
 
@@ -3035,7 +3002,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String srandmember(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#srandmember-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#srandmember-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.srandmember", key);
 
@@ -3052,7 +3019,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public List<String> srandmember(String key, int count) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#srandmember-java.lang.String-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#srandmember-java.lang.String-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.srandmember", key);
 
@@ -3069,7 +3036,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long srem(String key, String... members) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#srem-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#srem-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.srem", key);
 
@@ -3086,7 +3053,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public ScanResult<String> sscan(String key, String cursor) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sscan-java.lang.String-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sscan-java.lang.String-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sscan", key);
 
@@ -3103,7 +3070,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public ScanResult<String> sscan(String key, String cursor, ScanParams params) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sscan-java.lang.String-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sscan-java.lang.String-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sscan", key);
 
@@ -3120,7 +3087,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long strlen(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#strlen-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#strlen-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.strlen", key);
 
@@ -3137,7 +3104,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public void subscribe(JedisPubSub jedisPubSub, String... channels) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#subscribe-redis.clients.jedis.JedisPubSub-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#subscribe-redis.clients.jedis.JedisPubSub-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.subscribe", channels);
 
@@ -3154,7 +3121,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String substr(String key, int start, int end) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#substr-java.lang.String-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#substr-java.lang.String-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.substr", key);
 
@@ -3171,7 +3138,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> sunion(String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sunion-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sunion-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sunion", keys);
 
@@ -3188,7 +3155,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long sunionstore(String dstkey, String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#sunionstore-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#sunionstore-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.sunionstore", dstkey);
 
@@ -3205,7 +3172,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long ttl(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#ttl-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#ttl-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.ttl", key);
 
@@ -3222,7 +3189,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String type(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#type-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#type-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.type", key);
 
@@ -3239,7 +3206,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public String watch(String... keys) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#watch-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#watch-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.watch", keys);
 
@@ -3256,7 +3223,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zadd(String key, double score, String member) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zadd-java.lang.String-double-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zadd-java.lang.String-double-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zadd", key);
 
@@ -3273,7 +3240,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zadd(String key, double score, String member, ZAddParams params) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zadd-java.lang.String-double-java.lang.String-redis.clients.jedis.params.sortedset.ZAddParams-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zadd-java.lang.String-double-java.lang.String-redis.clients.jedis.params.sortedset.ZAddParams-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zadd", key);
 
@@ -3290,7 +3257,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zadd(String key, Map<String, Double> scoreMembers) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zadd-java.lang.String-java.util.Map-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zadd-java.lang.String-java.util.Map-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zadd", key);
 
@@ -3307,7 +3274,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zadd(String key, Map<String, Double> scoreMembers, ZAddParams params) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zadd-java.lang.String-java.util.Map-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zadd-java.lang.String-java.util.Map-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zadd", key);
 
@@ -3324,7 +3291,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zcard(String key) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zcard-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zcard-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zcard", key);
 
@@ -3341,7 +3308,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zcount(String key, double min, double max) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zcount-java.lang.String-double-double-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zcount-java.lang.String-double-double-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zcount", key);
 
@@ -3358,7 +3325,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zcount(String key, String min, String max) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zcount-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zcount-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zcount", key);
 
@@ -3375,7 +3342,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Double zincrby(String key, double score, String member) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zincrby-java.lang.String-double-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zincrby-java.lang.String-double-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zincrby", key);
 
@@ -3392,7 +3359,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Double zincrby(String key, double score, String member, ZIncrByParams params) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zincrby-java.lang.String-double-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zincrby-java.lang.String-double-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zincrby", key);
 
@@ -3409,7 +3376,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zinterstore(String dstkey, String... sets) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zinterstore-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zinterstore-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zinterstore", dstkey);
 
@@ -3426,7 +3393,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zinterstore(String dstkey, ZParams params, String... sets) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zinterstore-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zinterstore-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zinterstore", dstkey);
 
@@ -3443,7 +3410,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zlexcount(String key, String min, String max) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zlexcount-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zlexcount-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zlexcount", key);
 
@@ -3460,7 +3427,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> zrange(String key, long start, long end) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrange-java.lang.String-long-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrange-java.lang.String-long-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zrange", key);
 
@@ -3477,7 +3444,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> zrangeByLex(String key, String min, String max) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrangeByLex-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrangeByLex-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zrangeByLex", key);
 
@@ -3494,7 +3461,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> zrangeByLex(String key, String min, String max, int offset, int count) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrangeByLex-java.lang.String-java.lang.String-java.lang.String-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrangeByLex-java.lang.String-java.lang.String-java.lang.String-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zrangeByLex", key);
 
@@ -3511,7 +3478,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> zrangeByScore(String key, String min, String max) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrangeByScore-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrangeByScore-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zrangeByScore", key);
 
@@ -3528,7 +3495,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> zrangeByScore(String key, String min, String max, int offset, int count) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrangeByScore-java.lang.String-double-double-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrangeByScore-java.lang.String-double-double-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zrangeByScore", key);
 
@@ -3545,7 +3512,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<Tuple> zrangeByScoreWithScores(String key, double min, double max) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrangeByScoreWithScores-java.lang.String-double-double-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrangeByScoreWithScores-java.lang.String-double-double-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrangeByScoreWithScores", key);
@@ -3564,7 +3531,7 @@ public class OcWrapJedis extends Jedis {
   public Set<Tuple> zrangeByScoreWithScores(
       String key, double min, double max, int offset, int count) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrangeByScoreWithScores-java.lang.String-double-double-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrangeByScoreWithScores-java.lang.String-double-double-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrangeByScoreWithScores", key);
@@ -3582,7 +3549,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<Tuple> zrangeByScoreWithScores(String key, String min, String max) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrangeByScoreWithScores-java.lang.String-java.lang.String-java.lang.String-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrangeByScoreWithScores-java.lang.String-java.lang.String-java.lang.String-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrangeByScoreWithScores", key);
@@ -3601,7 +3568,7 @@ public class OcWrapJedis extends Jedis {
   public Set<Tuple> zrangeByScoreWithScores(
       String key, String min, String max, int offset, int count) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrangeByScoreWithScores-java.lang.String-java.lang.String-java.lang.String-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrangeByScoreWithScores-java.lang.String-java.lang.String-java.lang.String-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrangeByScoreWithScores", key);
@@ -3619,7 +3586,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<Tuple> zrangeWithScores(String key, long start, long end) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrangeWithScores-java.lang.String-long-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrangeWithScores-java.lang.String-long-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrangeWithScores", key);
@@ -3637,7 +3604,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zrank(String key, String member) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrank-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrank-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zrank", key);
 
@@ -3654,7 +3621,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zrem(String key, String... members) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrem-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrem-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zrem", key);
 
@@ -3671,7 +3638,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zremrangeByLex(String key, String min, String max) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zremrangeByLex-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zremrangeByLex-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zremrangeByLex", key);
 
@@ -3688,7 +3655,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zremrangeByRank(String key, long start, long end) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zremrangeByRank-java.lang.String-long-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zremrangeByRank-java.lang.String-long-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zremrangeByRank", key);
 
@@ -3705,7 +3672,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zremrangeByScore(String key, double start, double end) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zremrangeByScore-java.lang.String-double-double-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zremrangeByScore-java.lang.String-double-double-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zremrangeByScore", key);
@@ -3723,7 +3690,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zremrangeByScore(String key, String start, String end) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zremrangeByScore-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zremrangeByScore-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zremrangeByScore", key);
@@ -3741,7 +3708,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> zrevrange(String key, long start, long end) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrange-java.lang.String-long-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrange-java.lang.String-long-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zrevrange", key);
 
@@ -3758,7 +3725,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> zrevrangeByLex(String key, String max, String min) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrangeByLex-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrangeByLex-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zrevrangeByLex", key);
 
@@ -3775,7 +3742,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> zrevrangeByLex(String key, String max, String min, int offset, int count) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrangeByLex-java.lang.String-java.lang.String-java.lang.String-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrangeByLex-java.lang.String-java.lang.String-java.lang.String-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zrevrangeByLex", key);
 
@@ -3792,7 +3759,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> zrevrangeByScore(String key, double max, double min) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrangeByScore-java.lang.String-double-double-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrangeByScore-java.lang.String-double-double-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrevrangeByScore", key);
@@ -3810,7 +3777,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> zrevrangeByScore(String key, double max, double min, int offset, int count) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrangeByScore-java.lang.String-double-double-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrangeByScore-java.lang.String-double-double-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrevrangeByScore", key);
@@ -3828,7 +3795,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> zrevrangeByScore(String key, String max, String min) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrangeByScore-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrangeByScore-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrevrangeByScore", key);
@@ -3846,7 +3813,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<String> zrevrangeByScore(String key, String max, String min, int offset, int count) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrangeByLex-java.lang.String-java.lang.String-java.lang.String-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrangeByLex-java.lang.String-java.lang.String-java.lang.String-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrevrangeByScore", key);
@@ -3864,7 +3831,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(String key, double max, double min) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrangeByScoreWithScores-java.lang.String-double-double-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrangeByScoreWithScores-java.lang.String-double-double-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrevrangeByScoreWithScores", key);
@@ -3883,7 +3850,7 @@ public class OcWrapJedis extends Jedis {
   public Set<Tuple> zrevrangeByScoreWithScores(
       String key, double max, double min, int offset, int count) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrangeByScoreWithScores-java.lang.String-double-double-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrangeByScoreWithScores-java.lang.String-double-double-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrevrangeByScoreWithScores", key);
@@ -3901,7 +3868,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(String key, String max, String min) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrangeByScoreWithScores-java.lang.String-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrangeByScoreWithScores-java.lang.String-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrevrangeByScoreWithScores", key);
@@ -3920,7 +3887,7 @@ public class OcWrapJedis extends Jedis {
   public Set<Tuple> zrevrangeByScoreWithScores(
       String key, String max, String min, int offset, int count) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrangeByScoreWithScores-java.lang.String-java.lang.String-java.lang.String-int-int-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrangeByScoreWithScores-java.lang.String-java.lang.String-java.lang.String-int-int-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrevrangeByScoreWithScores", key);
@@ -3938,7 +3905,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Set<Tuple> zrevrangeWithScores(String key, long start, long end) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrangeWithScores-java.lang.String-long-long-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrangeWithScores-java.lang.String-long-long-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan(
             "redis.clients.jedis.Jedis.zrevrangeWithScores", key);
@@ -3956,7 +3923,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zrevrank(String key, String member) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zrevrank-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zrevrank-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zrevrank", key);
 
@@ -3973,7 +3940,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public ScanResult<Tuple> zscan(String key, String cursor) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zscan-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zscan-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zscan", key);
 
@@ -3990,7 +3957,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public ScanResult<Tuple> zscan(String key, String cursor, ScanParams params) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zscan-java.lang.String-java.lang.String-redis.clients.jedis.ScanParams-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zscan-java.lang.String-java.lang.String-redis.clients.jedis.ScanParams-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zscan", key);
 
@@ -4007,7 +3974,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Double zscore(String key, String member) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zscore-java.lang.String-java.lang.String-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zscore-java.lang.String-java.lang.String-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zscore", key);
 
@@ -4024,7 +3991,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zunionstore(String dstkey, String... sets) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zunionstore-java.lang.String-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zunionstore-java.lang.String-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zunionstore", dstkey);
 
@@ -4041,7 +4008,7 @@ public class OcWrapJedis extends Jedis {
   @Override
   public Long zunionstore(String dstkey, ZParams params, String... sets) {
     // This method makes a call over the network.
-    // https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#zunionstore-java.lang.String-redis.clients.jedis.ZParams-java.lang.String...-
+    // https://static.javadoc.io/redis.clients/jedis/3.0.1/redis/clients/jedis/Jedis.html#zunionstore-java.lang.String-redis.clients.jedis.ZParams-java.lang.String...-
     TrackingOperation trackingOperation =
         Observability.createRoundtripTrackingSpan("redis.clients.jedis.Jedis.zunionstore", dstkey);
 


### PR DESCRIPTION
Since the update from 2.9.0 to 3.X.X, Jedis has
undergone some changes which are mostly import path
updates but not much change to the API surface.

This change incorporates using Jedis 3.0.1 and also
updates the gradle build version to 0.0.3.